### PR TITLE
feat: severity calibration & Blocking field (closes #1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 docs/
+.fellowship/

--- a/plugin/commands/fight.md
+++ b/plugin/commands/fight.md
@@ -55,9 +55,25 @@ Verdict: Solid | Needs Work | Insufficient | No Confidence
 Verdict: Ready to Ship | Needs Hardening | High Risk | Do Not Ship
 
 ---
+
+## Blocking (must fix before merge)
+[Cross-lens list of every finding with Blocking: Yes. Empty section if none.]
+
+## Follow-up (track as issues, do not block merge)
+[Cross-lens list of every finding with Blocking: No. Group by lens.]
+
+---
 ## Overall Verdict
-[APPROVED / NEEDS WORK / REJECT]
+[APPROVED / APPROVED (with follow-ups) / NEEDS WORK / REJECT]
 [2-3 sentences: biggest risks, blockers, recommended next action]
 ```
 
-The overall verdict is REJECT if any reviewer issues Broken, Critical, or Do Not Ship. NEEDS WORK if any reviewer flags issues. APPROVED only if all reviewers clear.
+### Verdict rules
+
+The overall verdict is determined by **Blocking** findings, not by severity alone:
+
+- **REJECT** if 2+ Blocking=Yes Critical findings, OR any lens returns a terminal verdict (Broken / Do Not Ship / Critical / Will Not Scale / No Confidence).
+- **NEEDS WORK** if 1+ Blocking=Yes findings exist.
+- **APPROVED** if zero Blocking=Yes findings. Use **APPROVED (with follow-ups)** when Non-blocking Major/Minor items exist — the author should open tracking issues for them but they do not gate the merge.
+
+A finding is **Blocking** when: shipping it unfixed causes a failure the author could not have predicted, or leaves the system in a state that is expensive to reverse. Severity measures impact; Blocking measures merge-gate posture. Most architectural and test-coverage findings are non-blocking.

--- a/plugin/commands/fight.md
+++ b/plugin/commands/fight.md
@@ -72,7 +72,7 @@ Verdict: Ready to Ship | Needs Hardening | High Risk | Do Not Ship
 
 The overall verdict is determined by **Blocking** findings, not by severity alone:
 
-- **REJECT** if 2+ Blocking=Yes Critical findings, OR any lens returns a terminal verdict (Broken / Do Not Ship / Critical / Will Not Scale / No Confidence).
+- **REJECT** if 2+ Blocking=Yes Critical findings, OR any lens returns a terminal verdict (Broken / Do Not Ship / Critical / Blocking Issue / No Confidence).
 - **NEEDS WORK** if 1+ Blocking=Yes findings exist.
 - **APPROVED** if zero Blocking=Yes findings. Use **APPROVED (with follow-ups)** when Non-blocking Major/Minor items exist — the author should open tracking issues for them but they do not gate the merge.
 

--- a/plugin/skills/adversarial-architect/SKILL.md
+++ b/plugin/skills/adversarial-architect/SKILL.md
@@ -167,7 +167,7 @@ If you find yourself writing a finding that isn't about structure, discard it.
 You are not trying to be fair to the author. You are trying to find every place the composition fails. Apply maximum pressure:
 
 - **Do not accept "it works" as justification for poor structure.** Working is the minimum bar. Structure is what determines whether it stays working.
-- **Do not soften findings to be polite.** If a class does eight things, say it does eight things. (But "says eight things" is Major-with-Follow-up, not a merge blocker.)
+- **Do not soften findings to be polite.** If a class does eight things, say it does eight things. (But a class doing eight things is Major-with-Follow-up, not a merge blocker — the finding is sharp, the merge-gate posture stays calibrated.)
 - **Do not accept "it's just one file" as an excuse.** File size and unit responsibility are independent.
 - **If you cannot identify a violation, say so explicitly** — don't manufacture findings, but don't go soft to seem balanced.
 - **Call out non-idiomatic usage.** If the author is fighting the language instead of working with it, name it. The language has conventions for a reason.

--- a/plugin/skills/adversarial-architect/SKILL.md
+++ b/plugin/skills/adversarial-architect/SKILL.md
@@ -123,11 +123,14 @@ Mark each: `(essential)`, `(accidental)`, `(crossing wrong boundary)`.
 ### Findings
 
 For each finding:
-- **[Axis] — [Title]** — Severity: Critical / Major / Minor
+- **[Axis] — [Title]** — Severity: Major / Minor / Follow-up | Blocking: Yes / No
+- **Trigger condition:** when this structural debt becomes load-bearing (e.g. "the next time someone adds an auth provider", "when this module grows past ~500 lines", "the first time this needs a second caller")
 - Quote the specific code
 - State the principle violated
 - State what it costs (testability, changeability, readability)
 - State the fix in one sentence — no hand-holding
+
+**Blocking** is almost never Yes for an Architect finding. Structural debt on working code does not gate a merge. Mark Blocking=Yes only when the author is literally blocked on their next task by the design — e.g. the next feature cannot be added without first fixing this. Everything else is a Follow-up issue to track, not a merge gate.
 
 ### Challenge Questions
 
@@ -138,11 +141,15 @@ End with 3–5 pointed questions the author should be forced to answer:
 
 ## Severity Rubric
 
+Architect severity caps at **Major**. Structural findings on working code are not merge-blockers — they are debt to plan against. Use Follow-up liberally.
+
 | Severity | Meaning |
 |----------|---------|
-| **Critical** | Structural failure. Adding any feature requires touching this. Testing requires production infrastructure. |
-| **Major** | Clear violation of a principle with measurable cost. Design survives but degrades over time. |
-| **Minor** | Smell. Not a crisis today, becomes one at scale. |
+| **Major** | The next feature in this area is blocked by this design, or testing requires production infrastructure. Author should address before proceeding. |
+| **Minor** | Clear violation of a principle with measurable cost. Design survives but degrades over time. |
+| **Follow-up** | Real debt worth tracking as an issue. Not a crisis today. Do not fix now — open a ticket. |
+
+If you find yourself wanting to call something "Critical" — downgrade it to Major and ask whether it Blocks the next feature. If it doesn't, it's Minor or Follow-up.
 
 ## What Is Out of Scope
 
@@ -160,7 +167,7 @@ If you find yourself writing a finding that isn't about structure, discard it.
 You are not trying to be fair to the author. You are trying to find every place the composition fails. Apply maximum pressure:
 
 - **Do not accept "it works" as justification for poor structure.** Working is the minimum bar. Structure is what determines whether it stays working.
-- **Do not soften critical findings.** If a class does eight things, say it does eight things.
+- **Do not soften findings to be polite.** If a class does eight things, say it does eight things. (But "says eight things" is Major-with-Follow-up, not a merge blocker.)
 - **Do not accept "it's just one file" as an excuse.** File size and unit responsibility are independent.
 - **If you cannot identify a violation, say so explicitly** — don't manufacture findings, but don't go soft to seem balanced.
 - **Call out non-idiomatic usage.** If the author is fighting the language instead of working with it, name it. The language has conventions for a reason.

--- a/plugin/skills/adversarial-auditor/SKILL.md
+++ b/plugin/skills/adversarial-auditor/SKILL.md
@@ -109,10 +109,13 @@ Webhook callback → Handler (verified? yes/no)
 ### Findings
 
 For each finding:
-- **[Axis] — [Title]** — Severity: Critical / High / Medium / Low
+- **[Axis] — [Title]** — Severity: Critical / High / Medium / Low | Blocking: Yes / No
+- **Trigger condition:** what an attacker needs to exploit this — attack surface, auth level, specific input (e.g. "any unauthenticated HTTP request to `/api/chat`", "authenticated user with `role=viewer`", "attacker who has stolen a session token")
 - Describe the vulnerability precisely
 - State the concrete attack scenario: "An attacker can X by doing Y, resulting in Z"
 - State the fix in one sentence — no hand-holding
+
+**Blocking** means: the vulnerability is reachable from a public or low-privilege attack surface that exists on this branch. Defense-in-depth and hardening items are non-blocking; exploitable auth, authz, injection, or data-exposure vulns are Blocking.
 
 ### Attack Scenarios
 

--- a/plugin/skills/adversarial-auditor/SKILL.md
+++ b/plugin/skills/adversarial-auditor/SKILL.md
@@ -110,12 +110,12 @@ Webhook callback → Handler (verified? yes/no)
 
 For each finding:
 - **[Axis] — [Title]** — Severity: Critical / High / Medium / Low | Blocking: Yes / No
-- **Trigger condition:** what an attacker needs to exploit this — attack surface, auth level, specific input (e.g. "any unauthenticated HTTP request to `/api/chat`", "authenticated user with `role=viewer`", "attacker who has stolen a session token")
+- **Trigger condition:** what an attacker needs to exploit this — attack surface, auth level, specific input (e.g. "any unauthenticated HTTP request to `/api/chat`", "authenticated user with `role=viewer`", "attacker with a stolen `role=viewer` session token on a network path to the admin API")
 - Describe the vulnerability precisely
 - State the concrete attack scenario: "An attacker can X by doing Y, resulting in Z"
 - State the fix in one sentence — no hand-holding
 
-**Blocking** means: the vulnerability is reachable from a public or low-privilege attack surface that exists on this branch. Defense-in-depth and hardening items are non-blocking; exploitable auth, authz, injection, or data-exposure vulns are Blocking.
+**Blocking** means: an exploitable vulnerability reachable from a public or low-privilege attack surface that exists on this branch. This applies across all six axes — injection, auth bypass, authorization failure, data exposure, cryptographic weakness, and trust-boundary violation are all Blocking when reachable from a real attack surface. Defense-in-depth and hardening improvements that are not directly exploitable from a reachable attack surface are non-blocking.
 
 ### Attack Scenarios
 

--- a/plugin/skills/adversarial-optimizer/SKILL.md
+++ b/plugin/skills/adversarial-optimizer/SKILL.md
@@ -123,11 +123,14 @@ processQueue(n events) → O(n²) comparison step
 ### Findings
 
 For each finding:
-- **[Axis] — [Title]** — Severity: Critical / Major / Minor
+- **[Axis] — [Title]** — Severity: Critical / Major / Minor | Blocking: Yes / No
+- **Trigger condition:** the specific scale at which this becomes observable — cite evidence, not assumptions. If you don't know current deployed scale, say so and downgrade severity. (e.g. "at >10k rows in the `refs` table — currently ~50k, so active today"; "at >1M refs — not current scale, follow-up only")
 - Describe the inefficiency precisely
 - State the impact at scale: "At X items / Y concurrent users / Z load, this results in..."
 - Include a rough estimate of magnitude where possible
 - State the fix in one sentence — no hand-holding
+
+**Blocking** means: the finding is observable at current or near-term (<6 months) documented scale. A finding that requires 100x current scale to bite is Follow-up territory, not Blocking — no matter how dramatic the projected impact.
 
 ### Scaling Projections
 
@@ -139,11 +142,13 @@ End with expected behavior as load increases:
 
 ## Severity Rubric
 
+Severity requires **evidence of scale**, not assumed scale. Cite the current deployed data volume, request rate, or concurrency — if you can't cite it, downgrade.
+
 | Severity | Meaning |
 |----------|---------|
-| **Critical** | Will cause an incident at realistic load projections. O(n²) on growing data, N+1 on production table sizes, unbounded memory growth. |
-| **Major** | Measurable inefficiency at current scale. Will become critical as load grows. |
-| **Minor** | Sub-optimal but not a scaling risk. Worth fixing but not blocking. |
+| **Critical** | >10x degradation (latency, throughput, or resource usage) at **documented current or near-term target scale**. N+1 that fires thousands of times per request today, unbounded memory growth observable in production. |
+| **Major** | Measurable inefficiency at current scale that will reach Critical within the next scale doubling. |
+| **Minor** | Sub-optimal. May become a problem at >10x current scale, or wastes resources without changing correctness or user-visible latency. |
 
 ## What Is Out of Scope
 

--- a/plugin/skills/adversarial-optimizer/SKILL.md
+++ b/plugin/skills/adversarial-optimizer/SKILL.md
@@ -124,13 +124,16 @@ processQueue(n events) → O(n²) comparison step
 
 For each finding:
 - **[Axis] — [Title]** — Severity: Critical / Major / Minor | Blocking: Yes / No
-- **Trigger condition:** the specific scale at which this becomes observable — cite evidence, not assumptions. If you don't know current deployed scale, say so and downgrade severity. (e.g. "at >10k rows in the `refs` table — currently ~50k, so active today"; "at >1M refs — not current scale, follow-up only")
+- **Trigger condition:** the scale or access pattern at which this becomes observable.
+  - For **structural issues** (unbounded growth, O(n²), N+1, missing index): cite the algorithm and the scale at which it bites. These stand at their natural severity regardless of whether you have deployed-scale metrics.
+  - For **scale-dependent claims** ("this will be slow at 5M rows"): cite current deployed scale as evidence. If you don't have it, flag the finding as "scale verification needed" and do not escalate severity based on assumed scale.
+  - Example: "N+1 on `SELECT * FROM refs WHERE parent_id = ?` — fires once per item in the outer loop, observable today at current scale"; "at >1M refs — not current scale, scale verification needed before escalation"
 - Describe the inefficiency precisely
 - State the impact at scale: "At X items / Y concurrent users / Z load, this results in..."
 - Include a rough estimate of magnitude where possible
 - State the fix in one sentence — no hand-holding
 
-**Blocking** means: the finding is observable at current or near-term (<6 months) documented scale. A finding that requires 100x current scale to bite is Follow-up territory, not Blocking — no matter how dramatic the projected impact.
+**Blocking × Severity.** Critical findings are Blocking by construction — they manifest at reachable scale. Major findings are usually Blocking when they affect the current code path. Minor findings are never Blocking; they become follow-up issues.
 
 ### Scaling Projections
 
@@ -142,13 +145,13 @@ End with expected behavior as load increases:
 
 ## Severity Rubric
 
-Severity requires **evidence of scale**, not assumed scale. Cite the current deployed data volume, request rate, or concurrency — if you can't cite it, downgrade.
+Structural issues (unbounded growth, O(n²), N+1, missing index on a queried column) stand at their natural severity. Scale-dependent claims require evidence — cite current deployed scale, or downgrade.
 
-| Severity | Meaning |
-|----------|---------|
-| **Critical** | >10x degradation (latency, throughput, or resource usage) at **documented current or near-term target scale**. N+1 that fires thousands of times per request today, unbounded memory growth observable in production. |
-| **Major** | Measurable inefficiency at current scale that will reach Critical within the next scale doubling. |
-| **Minor** | Sub-optimal. May become a problem at >10x current scale, or wastes resources without changing correctness or user-visible latency. |
+| Severity | Meaning | Blocking |
+|----------|---------|---------|
+| **Critical** | Structural issue observable at current scale, OR >10x degradation (latency, throughput, or resources) at documented current or near-term target scale. Examples: N+1 firing thousands of times per request today, unbounded memory growth, full scan on a table that already has enough rows to matter. | Always |
+| **Major** | Measurable inefficiency on the current code path — bites at 2x–10x current scale, or wastes resources at current scale without >10x degradation. | Usually |
+| **Minor** | Wasteful but not a scaling risk at reachable scale. Bites only at substantially beyond near-term projected scale, or wastes resources without changing correctness or user-visible latency. | Never |
 
 ## What Is Out of Scope
 

--- a/plugin/skills/adversarial-qa/SKILL.md
+++ b/plugin/skills/adversarial-qa/SKILL.md
@@ -125,7 +125,7 @@ For each finding:
 - State the specific bug that would slip through: "If X were broken in Y way, these tests would still pass"
 - State the fix in one sentence — no hand-holding
 
-**Blocking** means: the gap covers a code path that is plausibly broken today — the suite would greenlight a regression the reviewer can articulate. Missing happy-path coverage is almost never Blocking. Untested failure modes on code the author just changed frequently are.
+**Blocking** means: the gap covers a code path that is plausibly broken today — the suite would greenlight a regression the reviewer can articulate. Missing happy-path coverage is almost never Blocking. Untested failure modes on code the author just changed are frequently Blocking.
 
 ### Bugs These Tests Would Miss
 

--- a/plugin/skills/adversarial-qa/SKILL.md
+++ b/plugin/skills/adversarial-qa/SKILL.md
@@ -119,10 +119,13 @@ Concurrent access → tested / not tested
 ### Findings
 
 For each finding:
-- **[Axis] — [Title]** — Severity: Critical / Major / Minor
+- **[Axis] — [Title]** — Severity: Critical / Major / Minor | Blocking: Yes / No
+- **Trigger condition:** the specific input, state, or failure mode that the test suite fails to exercise (e.g. "empty `userId` string in POST /auth", "DB timeout during transaction commit", "unicode whitespace in the `name` field")
 - Describe the gap precisely
 - State the specific bug that would slip through: "If X were broken in Y way, these tests would still pass"
 - State the fix in one sentence — no hand-holding
+
+**Blocking** means: the gap covers a code path that is plausibly broken today — the suite would greenlight a regression the reviewer can articulate. Missing happy-path coverage is almost never Blocking. Untested failure modes on code the author just changed frequently are.
 
 ### Bugs These Tests Would Miss
 
@@ -130,11 +133,13 @@ End with a concrete list of plausible bugs that could be introduced into this co
 
 ## Severity Rubric
 
+Critical requires a concrete correctness bug the reviewer can name — not just "coverage is missing." Missing tests for code that works correctly today downgrade to Major at most.
+
 | Severity | Meaning |
 |----------|---------|
-| **Critical** | A category of real bugs is completely untested. Regressions in this area would ship undetected. |
-| **Major** | Significant gap covering a realistic failure mode. Tests pass while the code is broken. |
-| **Minor** | Weak assertion or missing edge case. Reduces confidence but not a blind spot. |
+| **Critical** | The suite would pass with a correctness bug the reviewer can articulate, on code that's plausibly broken today. Regressions in this area would ship undetected. |
+| **Major** | Significant gap covering a realistic failure mode. Tests pass while the code is broken, but the specific bug requires speculation. Also: happy-path coverage missing on new code. |
+| **Minor** | Weak assertion, missing edge case, or low-likelihood gap. Reduces confidence but not a blind spot. |
 
 ## What Is Out of Scope
 

--- a/plugin/skills/adversarial-sre/SKILL.md
+++ b/plugin/skills/adversarial-sre/SKILL.md
@@ -119,11 +119,14 @@ Process restart mid-operation → [impact, detection time, recovery path]
 ### Findings
 
 For each finding:
-- **[Axis] — [Title]** — Severity: Critical / High / Medium / Low
+- **[Axis] — [Title]** — Severity: Critical / High / Medium / Low | Blocking: Yes / No
+- **Trigger condition:** the state/load/failure at which this finding becomes observable (e.g. "when the DB connection pool reaches 80% utilization", "on any process restart during a write", "at >500 concurrent requests")
 - Describe the failure mode precisely
 - State the incident scenario: "At X load / when Y fails / if Z happens, the result is..."
 - State the detection lag: "You would know about this in N minutes/hours/days because..."
 - State the fix in one sentence — no hand-holding
+
+**Blocking** means: shipping this unfixed will cause an incident the author could not have predicted, or leave the system in a state that is expensive to reverse. Silent-failure hazards and data-corruption risks are almost always Blocking. Observability gaps and recoverability improvements usually are not.
 
 ### Incident Scenarios
 


### PR DESCRIPTION
## Summary

Addresses #1 — separates "impact" (severity) from "merge gate" (Blocking) so triage cost drops on real `/fight` runs. Also tightens per-lens rubrics to require evidence of scale/exploitability rather than assertion.

## Changes

**Cross-cutting (all 5 SKILL.md files)**
- Every finding now carries `Blocking: Yes/No` alongside severity.
- Every finding carries a `Trigger condition:` line — the state, scale, or attack surface at which it becomes observable.

**Per-lens rubric calibration**

| Lens | Change |
|---|---|
| Architect | Severity capped at **Major**. `Critical` removed (structural debt on working code does not gate a merge). New `Follow-up` band for debt that should open an issue, not block the merge. |
| Optimizer | `Critical` requires **documented current or near-term target scale**. Speculative "at 5M rows" findings downgrade when deployed scale isn't cited. |
| QA | `Critical` requires a nameable correctness bug, not just missing coverage. Missing happy-path coverage is `Major` at most. |
| SRE | Per-finding Blocking guidance added; rubric unchanged. |
| Auditor | Per-finding Blocking guidance added; rubric unchanged. |

**/fight aggregation**
- Verdict now driven by Blocking count, not severity existence.
- `APPROVED` is reachable again: zero Blocking=Yes findings.
- New `APPROVED (with follow-ups)` verdict.
- Aggregated report now has cross-lens `Blocking` and `Follow-up` sections.

## Test plan

- [ ] Dry-run `/fight-club:fight` against a recent non-trivial diff and confirm the report includes Blocking/Trigger-condition fields and the new verdict options
- [ ] Confirm Architect no longer emits `Critical` findings
- [ ] Confirm Optimizer findings cite current deployed scale or self-downgrade
- [ ] Confirm clean PRs now receive `APPROVED` rather than `NEEDS WORK`

🤖 Generated with [Claude Code](https://claude.com/claude-code)